### PR TITLE
Fix dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-simple-typewriter": "^5.0.1",
-        "react-text-transition": "^3.1.0",
-        "vite-react-typescript-starter": "file:"
+        "react-text-transition": "^3.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.1",
@@ -4302,10 +4301,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/vite-react-typescript-starter": {
-      "resolved": "",
-      "link": true
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-simple-typewriter": "^5.0.1",
-    "react-text-transition": "^3.1.0",
-    "vite-react-typescript-starter": "file:"
+    "react-text-transition": "^3.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",


### PR DESCRIPTION
## Summary
- remove `vite-react-typescript-starter` dependency
- clean lockfile entry

## Testing
- `npm install` *(fails: unable to access npm registry)*

